### PR TITLE
Fix duplicate transcriber-2 entry in content.opf

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -91,10 +91,7 @@
 		<meta property="file-as" refines="#producer-2">Grigg, David</meta>
 		<meta property="se:url.homepage" refines="#producer-2">https://rightword.com.au/david.php</meta>
 		<meta property="role" refines="#producer-2" scheme="marc:relators">cov</meta>
-		<dc:contributor id="producer-2">David Grigg</dc:contributor>
-		<meta property="file-as" refines="#producer-2">Grigg, David</meta>
-		<meta property="se:url.homepage" refines="#producer-2">https://rightword.com.au/david.php</meta>
-		<meta property="role" refines="#producer-2" scheme="marc:relators">pfr</meta>
+		<meta property="se:role" refines="#producer-2" scheme="marc:relators">pfr</meta>
 	</metadata>
 	<manifest>
 		<item href="toc.xhtml" id="toc.xhtml" media-type="application/xhtml+xml" properties="nav"/>


### PR DESCRIPTION
David Grigg’s information had already been entered as producer-2 in content.opf. Because he had found and provided PD proof for the cover, I found it only fair that he be listed with the MARC relator tag cov—my only contribution to this was to accept the image and crop it, which was trivial in comparison.